### PR TITLE
re-establish targets availability before collecting summary reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## Development
 
+* Re-establish all targets availability after reboot
+
+  Contributed by Vadym Chepkov (@vchepkov)
+
 * Fixed a bug in `patching::puppet_facts` where the sub command would fail to run on 
   installations with custom `GEM_PATH` settings. (Bug Fix)
   

--- a/plans/init.pp
+++ b/plans/init.pp
@@ -236,6 +236,16 @@ plan patching (
     }
   }
 
+  ## Re-establish all targets availability after reboot
+  # This is necessary in case one of the groups affects the availability of a previous group.
+  # Two use cases here:
+  #  1. A later group is a hypervisor. In this instance the hypervisor will reboot causing the 
+  #     VMs to go offline and we need to wait for those child VMs to come back up before
+  #     collecting history metrics.
+  #  2. A later group is a linux router. In this instance maybe the patching of the linux router
+  #     affects the reachability of previous hosts.
+  wait_until_available($targets, wait_time => 300)
+
   ## Collect summary report
   run_plan('patching::update_history',
             nodes  => $targets,


### PR DESCRIPTION
In scenarios where patching target groups with higher orders affects
status of the groups with lower order, for example, Linux hypervisor or Linux router,
availability of the targets should be re-establised prior collecting reports