### PR TITLE
use 'name' instead of 'host' to better represent targets in inventory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## Development
 
+* use 'name' instead of 'host' to better represent targets in inventory
+
+  Contributed by Vadym Chepkov (@vchepkov)
 
 ## Release 1.0.0 (2020-02-28)
 

--- a/plans/available_updates.pp
+++ b/plans/available_updates.pp
@@ -72,7 +72,7 @@ plan patching::available_updates (
     'csv': {
       $csv_header = 'hostname,num_updates,name,version (linux only),kbs (windows only)\n'
       $csv = $available_results.reduce($csv_header) |$res_memo, $res| {
-        $hostname = $res.target.host
+        $hostname = $res.target.name
         $num_updates = $res['updates'].length
         $host_updates = $res['updates'].reduce('') |$up_memo, $up| {
           $name = $up['name']

--- a/plans/ordered_groups.pp
+++ b/plans/ordered_groups.pp
@@ -115,7 +115,7 @@ plan patching::ordered_groups (
   $ordered_keys = sort(keys($ordered_hash))
   out::message("Groups = ${ordered_keys}")
   $ordered_groups = $ordered_keys.map |$o| {
-    $ordered_targets = $ordered_hash[$o].map |$t| {$t.host}
+    $ordered_targets = $ordered_hash[$o].map |$t| {$t.name}
     out::message("Group '${o}' targets = ${ordered_targets}")
     # trust me, we have to assign to a variable here, it's a detail of the puppet
     # language parser that gets mad, but only because there is the loop above

--- a/plans/update_history.pp
+++ b/plans/update_history.pp
@@ -67,7 +67,7 @@ plan patching::update_history (
     'csv': {
       $csv_header = "host,action,name,version,kb (windows only)\n"
       $report = $_history.reduce($csv_header) |$res_memo, $res| {
-        $hostname = $res.target.host
+        $hostname = $res.target.name
         $num_updates = $res['upgraded'].length
         $host_updates = $res['upgraded'].reduce('') |$up_memo, $up| {
           $name = $up['name']


### PR DESCRIPTION
In cases where targets have 'uri' configured, using host field would represent an IP, for example,
instead of a canonical name assiged to the target