### PR TITLE
Changing the path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ All notable changes to this project will be documented in this file.
 
   Contributed by Vadym Chepkov (@vchepkov)
 
+* Modified location of the puppet executable on Linux to use the supported wrapper. This sets
+  library paths to solve consistency issues. (Bug Fix)
+  
+  Contributed by Michael Surato (@msurato)
+
 ## Release 0.4.0 (2020-01-06)
 
 * Add support for SUSE Linux Enterprise. (Enhancement)

--- a/tasks/puppet_facts.rb
+++ b/tasks/puppet_facts.rb
@@ -29,7 +29,7 @@ def puppet_executable
         File.join(installed_dir, 'bin', 'puppet')
       end
   else
-    puppet = '/opt/puppetlabs/puppet/bin/puppet'
+    puppet = '/opt/puppetlabs/bin/puppet'
   end
 
   # Fall back to PATH lookup if puppet-agent isn't installed


### PR DESCRIPTION
/opt/puppetlabs/bin/puppet calls a wrapper that fixes paths and performs a couple of other interesting changes that helps to ensure that puppet is called correctly. This change calls this instead of skipping the wrapper.