### PR TITLE
hostname as target_name_property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ All notable changes to this project will be documented in this file.
 
 Contributed by Michael Surato (@msurato)
 
+* Add `hostname` as a choice for patching::snapshot_vmware::target_name_property
+  It can be used in cases where target discovery uses fully qualified domain names
+  and VM names don't have domain name component
+
+  Contributed by Vadym Chepkov (@vchepkov)
+
 ## Release 1.0.1 (2020-03-04)
 
 * Ensure the `patching.json` file exists on Windows by creating a blank file if it was previously missing.

--- a/functions/target_names.pp
+++ b/functions/target_names.pp
@@ -3,16 +3,19 @@
 # @param [TargetSpec] targets
 #   List of targets to extract the name from
 #
-# @param [Enum['name', 'uri']] name_property
+# @param [Enum['hostname', 'name', 'uri']] name_property
 #   Property in the Target to use as the name
 #
 # @return [Array[String]] Array of names, one for each target
 function patching::target_names(
   TargetSpec          $targets,
-  Enum['name', 'uri'] $name_property,
+  Enum['hostname', 'name', 'uri'] $name_property,
 ) >> Array[String] {
   $targets.map |$n| {
     case $name_property {
+      'hostname': {
+        regsubst($n.uri, '^([^.]+).*','\1')
+      }
       'name': {
         $n.name
       }

--- a/plans/snapshot_vmware.pp
+++ b/plans/snapshot_vmware.pp
@@ -19,7 +19,7 @@
 #     - `create` creates a new snapshot
 #     - 'delete' deletes snapshots by matching the `snapshot_name` passed in.
 #
-# @param [Optional[Enum['name', 'uri']]] target_name_property
+# @param [Optional[Enum['hostname', 'name', 'uri']]] target_name_property
 #   Determines what property on the Target object will be used as the VM name when
 #   mapping the Target to a VM in vSphere.
 #
@@ -28,6 +28,8 @@
 #       list is set as the `uri` and not the `name`, in this case `name` will be `undef`.
 #    - `name` : use the `name` property on the Target, this is not preferred because
 #       `name` is usually a short name or nickname.
+#    - `hostname`: use the `hostname` value to use host component of `uri` property on the Target
+#      this can be useful if VM name doesn't include domain name
 #
 # @param [String[1]] vsphere_host
 #   Hostname of the vSphere server that we're going to use to create snapshots via the API.
@@ -63,7 +65,7 @@
 plan patching::snapshot_vmware (
   TargetSpec $targets,
   Enum['create', 'delete'] $action,
-  Optional[Enum['name', 'uri']] $target_name_property = undef,
+  Optional[Enum['hostname', 'name', 'uri']] $target_name_property = undef,
   String[1] $vsphere_host       = get_targets($targets)[0].vars['vsphere_host'],
   String[1] $vsphere_username   = get_targets($targets)[0].vars['vsphere_username'],
   String[1] $vsphere_password   = get_targets($targets)[0].vars['vsphere_password'],


### PR DESCRIPTION
add `hostname` as a choice for patching::snapshot_vmware::target_name_property

it can be used in cases where target discovery uses fully qualified domain names
and VM names don't have domain name component