### PR TITLE
updated metadata files

### DIFF
--- a/tasks/available_updates.json
+++ b/tasks/available_updates.json
@@ -21,7 +21,7 @@
   "parameters": {
     "provider": {
       "description": "What update provider to use. For Linux (RHEL, Debian, SUSE, etc.) this parameter is not used. For Windows the available values are: 'windows', 'chocolatey', 'all' (both 'windows' and 'chocolatey'). The default value for Windows is 'all'. If 'all' is passed and Chocolatey isn't installed then Chocolatey will simply be skipped. If 'chocolatey' is passed and Chocolatey isn't installed, then this will error.",
-      "type": "Optional[String[1]]"
+      "type": "Optional[String]"
     }
   }
 }

--- a/tasks/update.json
+++ b/tasks/update.json
@@ -20,7 +20,7 @@
   "parameters": {
     "provider": {
       "description": "What update provider to use. For Linux (RHEL, Debian, etc) this parameter is not used. For Windows the available values are: 'windows', 'chocolatey', 'all' (both 'windows' and 'chocolatey'). The default value for Windows is 'all'. If 'all' is passed and Chocolatey isn't installed then Chocolatey will simply be skipped. If 'chocolatey' is passed and Chocolatey isn't installed, then this will error.",
-      "type": "Optional[String[1]]"
+      "type": "Optional[String]"
     },
     "names": {
       "description": "Name of the package(s) to update. If nothing is passed then all packages will be updated. Note: this currently only works for Linux, Windows support will be added in the future for both Windows Update and Chocolatey (TODO)",


### PR DESCRIPTION
The type for the provider argument in tasks/available_updates.json and tasks/update.json were String[1] instead of String.

When not specifying patching_update_provider in my bolt config I would get the error:

`{
  "kind": "bolt/pal-error",
  "msg": "Task patching::update:\n parameter 'provider' expects a value of type Undef or String[1], got String (file: /Users/bsirinek/patchingtasks/Boltdir/modules/patching/plans/init.pp, line: 233)",
  "details": {
  }
}`

It does not matter to check if the String is 1 or more characters long, an empty string will likely produce the same result as putting any string other than "all", "windows" or "chocolatey" as the value. I suppose this should probably be an Eval.

