### PR TITLE
plans/reboot_required: set return variables when noop is true

### DIFF
--- a/plans/reboot_required.pp
+++ b/plans/reboot_required.pp
@@ -103,6 +103,8 @@ plan patching::reboot_required (
   }
   else {
     out::message('Noop specified, skipping all reboots.')
+    $targets_reboot_attempted = []
+    $reboot_resultset = ResultSet([])
   }
 
   # return our results


### PR DESCRIPTION
Fix #66 