### PR TITLE
Reboot Strategy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 ## Development
 
+- Fixed issue where agruments for reboot strategy are being overridden by
+  inventory file.
+
+  Contributed by Bradley Bishop (@bishopbm1)
+
 - Switch from Travis to GitHub Actions
 
   Contributed by Nick Maludy (@nmaludy)
@@ -29,10 +34,10 @@ All notable changes to this project will be documented in this file.
   Contributed by Haroon Rafique
 
 * Added new configuration option:
-  * `patching_update_provider`: Parameter sets the provider in the update tasks. 
+  * `patching_update_provider`: Parameter sets the provider in the update tasks.
 
   Contributed by Bill Sirinek (@sirinek)
-  
+
 * Fixed bug in `patching::available_updates_windows` where if `choco outdated` printed an
   error, but returned a `0` exit status our output parsing code was throwing an exception
   causing a unhelpful error to be printed. Now, we check for this condition and if we
@@ -73,7 +78,7 @@ All notable changes to this project will be documented in this file.
 * Added new configuration options:
   * `patching_reboot_wait`: Parameter controls the `reboot_wait` option for the number of seconds
     to wait between reboots. Default = 300
-  * `paching_report_file`: Customize the name of the report file to write to disk. You 
+  * `paching_report_file`: Customize the name of the report file to write to disk. You
     can disable writing the report files by specifying this as `'disabled'`.
     NOTE: for PE users writing files to disk throws an error, so you'll be happy you can
     now disable writing these files!
@@ -82,12 +87,12 @@ All notable changes to this project will be documented in this file.
     Default = `pretty`
 
   (Enhancement)
-  
+
   Contributed by Nick Maludy (@nmaludy)
-  
+
 * To support the new configuration options above, the `patching::reboot_required` plan
   had its parameter `reboot_wait` renamed to `wait`.  (Enhancement)
-  
+
   Contributed by Nick Maludy (@nmaludy)
 
 ## Release 1.0.1 (2020-03-04)

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "encore-patching",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "author": "Encore Technologies",
   "summary": "Implements OS patching workflows using Bolt tasks and plans.",
   "license": "Apache-2.0",

--- a/plans/reboot_required.pp
+++ b/plans/reboot_required.pp
@@ -44,16 +44,22 @@
 #
 plan patching::reboot_required (
   TargetSpec  $targets,
-  Enum['only_required', 'never', 'always'] $strategy = 'only_required',
-  String     $message = 'NOTICE: This system is currently being updated.',
-  Integer    $wait    = 300,
+  Enum['only_required', 'never', 'always'] $strategy = undef,
+  String     $message = undef,
+  Integer    $wait    = undef,
   Boolean    $noop    = false,
 ) {
   $_targets = run_plan('patching::get_targets', $targets)
   $group_vars = $_targets[0].vars
-  $_strategy = pick($group_vars['patching_reboot_strategy'], $strategy)
-  $_message = pick($group_vars['patching_reboot_message'], $message)
-  $_wait = pick($group_vars['patching_reboot_wait'], $wait)
+  $_strategy = pick($strategy,
+                    $group_vars['patching_reboot_strategy'],
+                    'only_required')
+  $_message = pick($message,
+                    $group_vars['patching_reboot_message'],
+                    'NOTICE: This system is currently being updated.')
+  $_wait = pick($wait,
+                $group_vars['patching_reboot_wait'],
+                300)
 
   ## Check if reboot required.
   $reboot_results = run_task('patching::reboot_required', $_targets)


### PR DESCRIPTION
Fixed issue where arguments passed on the command line was being overridden by the inventory file.

`# bolt plan run patching targets=test.domain.tld reboot_strategy='never' snapshot_delete=false
Starting: plan patching
....
Finished: plan patching::ordered_groups in 0.02 sec
Picked Reboot strategy: never
...
Reboot strategy: always
Host reboot required status: ('+' reboot required; '-' reboot NOT required)
 + test2.domain.tld
Starting: plan reboot
Starting: plan reboot
...
Finished: plan patching in 133.55 sec                                                                                                                                  
Plan completed successfully with no result
`