### PR TITLE
Patching facts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 ## Development
 
+- Fixed issue where puppet facts were not in the expected spot causing
+  puppet_facts plan to fail. We added a conditional to check for the facts
+  in both places
+
+  Contributed by Bradley Bishop (@bishopbm1)
+
 ## Release 1.2.1 (2021-02-02)
 
 - Fixed issue where agruments for reboot strategy are being overridden by

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "encore-patching",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "author": "Encore Technologies",
   "summary": "Implements OS patching workflows using Bolt tasks and plans.",
   "license": "Apache-2.0",

--- a/plans/puppet_facts.pp
+++ b/plans/puppet_facts.pp
@@ -23,7 +23,14 @@ plan patching::puppet_facts(
   #
   # We only want to set the "values" as facts on the node
   $result_set.each |$result| {
-    add_facts($result.target, $result.value['values'])
+    # Debian systems to not have values param they are just in the value return
+    if 'values' in $result.value {
+      $target_fact_values = $result.value['values']
+    } else {
+      $target_fact_values = $result.value
+    }
+
+    add_facts($result.target, $target_fact_values)
   }
   return $result_set
 }


### PR DESCRIPTION
Added if block to handle facts being returned in nested values vs not on some machines.

Ubuntu server facts:
```
"target":"ubuntu.domain.tld","action":"task","object":"patching::puppet_facts","status":"success","value":{"lsbdistrelease":"16.04","lsbmajdistrelease":"16","lsbminordistrelease":"04","os":{"distro":{"release":{"full":"16.04","major":"16.04"},"id":"Ubuntu","codename":"xenial","description":"Ubuntu 16.04.7 LTS"},"release":{"full":"16.04","major":"16.04"},"architecture":"amd64","family":"Debian","hardware":"x86_64","name":"Ubuntu","selinux":{"enabled":false}},"operatingsystemmajrelease":"16.04","operatingsystemrelease":"16.04","lsbdistdescription":"Ubuntu 16.04.7 ...
```

RHEL server facts:
```
{"target":"rhel.domain.tld","action":"task","object":"patching::puppet_facts","status":"success","value":{"name":"rhel.domain.tld","values":{"aio_agent_version":"6.20.0","architecture":"x86_64","augeas":{"version":"1.12.0"},"augeasversion":"1.12.0","bios_release_date":"12/12/2018","bios_vendor":"Phoenix Technologies LTD","bios_version":"6.00"...
```
