### PR TITLE
Support for Puppet_Agent 6, Enforced puppetlabs/reboot > 3.0, Version bump 1.2.2

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "encore-patching",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "author": "Encore Technologies",
   "summary": "Implements OS patching workflows using Bolt tasks and plans.",
   "license": "Apache-2.0",
@@ -10,8 +10,12 @@
   "dependencies": [
     {
       "name": "puppetlabs/puppet_agent",
-      "version_requirement": ">= 2.2.0 < 3.0.0"
+      "version_requirement": ">= 2.2.0 < 7.0.0"
     },
+    {
+      "name": "puppetlabs/reboot",
+      "version_requirement": ">= 3.0.0"
+    }
     {
       "name": "puppetlabs/stdlib",
       "version_requirement": ">= 4.13.1 < 7.0.0"

--- a/metadata.json
+++ b/metadata.json
@@ -15,7 +15,7 @@
     {
       "name": "puppetlabs/reboot",
       "version_requirement": ">= 3.0.0"
-    }
+    },
     {
       "name": "puppetlabs/stdlib",
       "version_requirement": ">= 4.13.1 < 7.0.0"


### PR DESCRIPTION
Did some tests with puppet_agent 6 and newer reboot. Seems to work fine. See #76 