### PR TITLE
bump version requirements for puppetlabs/stdlib and puppetlabs/reboot

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -14,11 +14,11 @@
     },
     {
       "name": "puppetlabs/reboot",
-      "version_requirement": ">= 3.0.0 < 5.0.0"
+      "version_requirement": ">= 3.0.0 < 6.0.0"
     },
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.13.1 < 9.0.0"
+      "version_requirement": ">= 8.6.0 < 10.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
Could we please make a new release with this? 
commit 1ab7a6a requires stdlib 8.6+ since namespaced function appeared only there
Other modules also require minimum 8.6, peadm, for example


Module works fine with new versions
