### PR TITLE
Fix ReEnableGroup bug

### DIFF
--- a/functions/build_workflow.pp
+++ b/functions/build_workflow.pp
@@ -112,6 +112,7 @@ function patching::build_workflow(
     $monitoring_reenable_group = true
   } else {
     $monitoring_plan = []
+    $monitoring_reenable_group = false
   }
 
   # Determine if snapshots should be created


### PR DESCRIPTION
When we are not using monitoring the system errored out as we don't ensure that the monitoring_reenable_group is initialized.